### PR TITLE
Fix variable typo in JobManagerService

### DIFF
--- a/grails-app/services/grails/plugins/quartz/JobManagerService.groovy
+++ b/grails-app/services/grails/plugins/quartz/JobManagerService.groovy
@@ -49,7 +49,7 @@ class JobManagerService {
      */
     def getJobs(String group) {
         quartzScheduler.getJobNames(group).collect { jobName ->
-            JobDescriptor.build(quartzScheduler.getJobDetail(jobName, jobGroup), quartzScheduler)
+            JobDescriptor.build(quartzScheduler.getJobDetail(jobName, group), quartzScheduler)
         }
     }
 


### PR DESCRIPTION
Fix typo in JobManagerService.getJobs.
