### PR TITLE
API Change

### DIFF
--- a/QuartzGrailsPlugin.groovy
+++ b/QuartzGrailsPlugin.groovy
@@ -221,7 +221,8 @@ This plugin adds Quartz job scheduling features to Grails application.
                 // if job already exists, delete it from scheduler
                 def jobClass = application.getJobClass(event.source?.name)
                 if (jobClass) {
-                    scheduler.deleteJob(jobClass.fullName, jobClass.group)
+					def jobKey = new org.quartz.JobKey(jobClass.fullName, jobClass.group) 
+                    scheduler.deleteJob(jobKey)
                     log.debug("Job ${jobClass.fullName} deleted from the scheduler")
                 }
 


### PR DESCRIPTION
In the recent API, org.quartz.Scheduler.deleteJob(String jobName, String groupName) has been replaced by org.quartz.Scheduler.deleteJob(JobKey jobKey).

I've made the necessary changes to make it compatible with the new API.
