### PR TITLE
Allow the Setting of the Scheduler's Name

### DIFF
--- a/QuartzGrailsPlugin.groovy
+++ b/QuartzGrailsPlugin.groovy
@@ -91,6 +91,11 @@ This plugin adds Quartz job scheduling features to Grails application.
         quartzScheduler(SchedulerFactoryBean) {
             quartzProperties = config._properties
 
+            // Use the instanceName property to set the name of the scheduler
+            if (quartzProperties['org.quartz.scheduler.instanceName']) {
+                schedulerName = quartzProperties['org.quartz.scheduler.instanceName']
+            }
+
             // delay scheduler startup to after-bootstrap stage
             autoStartup = false
             if (config.jdbcStore) {


### PR DESCRIPTION
If the org.quartz.scheduler.instanceName property is set use it as the Scheduler's name. Otherwise, the Spring SchedulerFactoryBean will set the name of the Scheduler to be the same as the bean name, i.e., "quartzScheduler".
