### PR TITLE
Expose underlying job in GrailsJob

### DIFF
--- a/src/java/grails/plugins/quartz/GrailsJobFactory.java
+++ b/src/java/grails/plugins/quartz/GrailsJobFactory.java
@@ -112,7 +112,11 @@ public class GrailsJobFactory extends AdaptableJobFactory implements Application
             } else {
                 throw new UnableToInterruptJobException(job.getClass().getName() + " doesn't support interruption");
             }
-        }
+		}
+		
+		public Object getJob() {
+			return job;
+		}
     }
 
     /**


### PR DESCRIPTION
In order for the quartz-monitor Grails plugin to function error-free with StatelessGrailsJob (see https://github.com/jamescookie/quartz-monitor/blob/master/src/groovy/grails/plugins/quartz/QuartzDisplayJob.groovy#L30), the underlying job needs to be exposed.  There might be a different way to fix this issue in the quartz-monitor plugin, but this seemed like the least impactful way to resolve it.
