### PR TITLE
Allow dataSource to be overridden with the name of the bean in config.jd...

### DIFF
--- a/QuartzGrailsPlugin.groovy
+++ b/QuartzGrailsPlugin.groovy
@@ -99,7 +99,7 @@ This plugin adds Quartz job scheduling features to Grails application.
             // delay scheduler startup to after-bootstrap stage
             autoStartup = false
             if (config.jdbcStore) {
-                dataSource = ref('dataSource')
+                dataSource = ref(config.jdbcStoreDataSource ?: 'dataSource')
                 transactionManager = ref('transactionManager')
             }
             waitForJobsToCompleteOnShutdown = config.waitForJobsToCompleteOnShutdown


### PR DESCRIPTION
...bcStoreDataSource. 

Separating the DB connection pool that GORM uses from the one that Quartz uses allows us to both tune the connection pools individually as well as have the Quartz tables off in a DB that's separate from the one that's hosting our application data.
