### PR TITLE
Ability to specify a Quartz Job's JobDetail description within Job configuration

### DIFF
--- a/QuartzGrailsPlugin.groovy
+++ b/QuartzGrailsPlugin.groovy
@@ -310,6 +310,7 @@ This plugin adds Quartz job scheduling features to Grails application.
             "${fullName}Detail"(JobDetailFactoryBean) {
                 name = fullName
                 group = jobClass.group
+                jobDetailDescription = jobClass.description
                 concurrent = jobClass.concurrent
                 durability = jobClass.durability
                 requestsRecovery = jobClass.requestsRecovery

--- a/src/docs/guide/configuration.gdoc
+++ b/src/docs/guide/configuration.gdoc
@@ -49,6 +49,15 @@ By default Jobs are executed in concurrent fashion, so new Job execution can sta
 def concurrent = false
 {code}
 
+h4. Configuring description
+
+Quartz allows for each job to have a short description. This may be configured by adding a description field to your Job. The description can be accessed at runtime using the JobManagerService and inspecting the JobDetail object.
+
+{code}
+def description = "Example Job Description"
+{code}
+
+
 h4. Clustering
 
 Quartz plugin doesn't support clustering out-of-the-box now. However, you could use standard Quartz clustering configuration. Take a look at the [example provided by Burt Beckwith|http://docs.codehaus.org/download/attachments/78053/clustering_sample.tar.gz?version=1]. You'll also need to set jdbcStore configuration option to true .

--- a/src/docs/guide/scheduling.gdoc
+++ b/src/docs/guide/scheduling.gdoc
@@ -8,6 +8,7 @@ class MyJob {
     simple name: 'mySimpleTrigger', startDelay: 60000, repeatInterval: 1000  
   }
   def group = "MyGroup"
+  def description = "Example job with Simple Trigger"
 
   def execute(){
     print "Job run!"
@@ -30,6 +31,7 @@ class MyJob  {
     cron name: 'myTrigger', cronExpression: "0 0 6 * * ?"
   }
  def group = "MyGroup"
+ def description = "Example job with Cron Trigger"
 
  def execute(){
    print "Job run!"

--- a/src/java/grails/plugins/quartz/DefaultGrailsJobClass.java
+++ b/src/java/grails/plugins/quartz/DefaultGrailsJobClass.java
@@ -159,6 +159,12 @@ public class DefaultGrailsJobClass extends AbstractInjectableGrailsClass impleme
         return requestsRecovery == null ? DEFAULT_REQUESTS_RECOVERY : requestsRecovery;
     }
 
+    public String getDescription() {
+        String description = (String) getPropertyOrStaticPropertyOrFieldValue(DESCRIPTION, String.class);
+        if (description == null || "".equals(description)) return DEFAULT_DESCRIPTION;
+        return description;
+    }
+
     public Map getTriggers() {
         return triggers;
     }

--- a/src/java/grails/plugins/quartz/GrailsJobClass.java
+++ b/src/java/grails/plugins/quartz/GrailsJobClass.java
@@ -112,5 +112,12 @@ public interface GrailsJobClass extends InjectableGrailsClass {
      */
     public boolean isRequestsRecovery();
 
+    /**
+     * Get job's description used for configuring job details.
+     *
+     * @return description for this job
+     */
+    public String getDescription();
+
     public Map getTriggers();
 }

--- a/src/java/grails/plugins/quartz/GrailsJobClassConstants.java
+++ b/src/java/grails/plugins/quartz/GrailsJobClassConstants.java
@@ -45,6 +45,8 @@ public final class GrailsJobClassConstants {
 
     public static final String GROUP = "group";
 
+    public static final String DESCRIPTION = "description";
+
     public static final String CONCURRENT = "concurrent";
 
     public static final String SESSION_REQUIRED = "sessionRequired";
@@ -74,6 +76,8 @@ public final class GrailsJobClassConstants {
     public static final String DEFAULT_CRON_EXPRESSION = "0 0 6 * * ?";
 
     public static final String DEFAULT_GROUP = "GRAILS_JOBS";
+
+    public static final String DEFAULT_DESCRIPTION = "Grails Job";
 
     public static final boolean DEFAULT_CONCURRENT = true;
 

--- a/src/java/grails/plugins/quartz/JobDetailFactoryBean.java
+++ b/src/java/grails/plugins/quartz/JobDetailFactoryBean.java
@@ -47,6 +47,7 @@ public class JobDetailFactoryBean implements FactoryBean, InitializingBean {
 
     private String name;
     private String group;
+    private String description;
     private boolean concurrent;
     private boolean durability;
     private boolean requestsRecovery;
@@ -107,6 +108,14 @@ public class JobDetailFactoryBean implements FactoryBean, InitializingBean {
     }
 
     /**
+     * Sets the description on the Quartz JobDetail object
+     * @param description the description on the Quartz JobDetail object
+     */
+    public void setJobDetailDescription(String description) {
+        this.description = description;
+    }
+
+    /**
      * {@inheritDoc}
      *
      * @see org.springframework.beans.factory.InitializingBean#afterPropertiesSet()
@@ -127,6 +136,7 @@ public class JobDetailFactoryBean implements FactoryBean, InitializingBean {
         // Build JobDetail instance.
         jobDetail = newJob(jobClass)
                 .withIdentity(name,group)
+                .withDescription(description)
                 .storeDurably(durability)
                 .requestRecovery(requestsRecovery)
                 .usingJobData(JOB_NAME_PARAMETER, name)


### PR DESCRIPTION
Ability to specify a Quartz Job's JobDetail description within Job configuration. This is useful for applications which list current Quartz jobs' details for user display.
