### PR TITLE
Added workmanager config and reference

### DIFF
--- a/QuartzGrailsPlugin.groovy
+++ b/QuartzGrailsPlugin.groovy
@@ -116,6 +116,11 @@ class QuartzGrailsPlugin {
     }
 
     def configureScheduler = {config->
+        if (config.workManager) {
+            quartzJobExecutor(org.springframework.scheduling.commonj.WorkManagerTaskExecutor) {
+               workManagerName=config.workManagerName
+            }
+        }
         quartzScheduler(SchedulerFactoryBean) { bean ->
             quartzProperties = config._properties
 
@@ -132,6 +137,10 @@ class QuartzGrailsPlugin {
                 dataSource = ref(config.jdbcStoreDataSource ?: 'dataSource')
                 transactionManager = ref('transactionManager')
             }
+            if (config.workManager) {
+                taskExecutor=ref('quartzJobExecutor')
+            }
+            
             waitForJobsToCompleteOnShutdown = config.waitForJobsToCompleteOnShutdown
             exposeSchedulerInRepository = config.exposeSchedulerInRepository
             jobFactory = quartzJobFactory


### PR DESCRIPTION
Hi,
i have to use the Spring WorkManagerTaskExecutor for using quartz in WebSphere with the commonj.WorkManager. For this I had to change the plugin initialization. Please see the modified lines. It would be great, if it can be included into the official plugin code. If you think it should be more generalized (e.g to allow to use any spring taskexecutor), please tell me.
