### PR TITLE
Create plugin.yml

### DIFF
--- a/grails-app/conf/plugin.yml
+++ b/grails-app/conf/plugin.yml
@@ -1,0 +1,1 @@
+quartz.jdbcStore: false


### PR DESCRIPTION
Add default configuration to set `jdbcStore` to false to restore behavior similar to the grails 2.x version of the plugin