### PR TITLE
address CVE-2019-13990 by updating quartz from 2.2.3 to 2.3.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -65,7 +65,7 @@ dependencies {
 
   console "org.grails:grails-console"
 
-  compile("org.quartz-scheduler:quartz:2.2.3") {
+  compile("org.quartz-scheduler:quartz:2.3.2") {
     exclude module: 'slf4j-api'
     exclude module: 'c3p0'
   }


### PR DESCRIPTION
The latest version of the grails quartz plugin, currently 2.0.13, has the vulnerability [CVE-2019-13990](https://nvd.nist.gov/vuln/detail/cve-2019-13990).  This issue is addressed by updating to quartz 2.3.2.  Instead of users updating the dependency themselves, [see example](https://github.com/grails-plugins/grails-quartz/issues/115#issuecomment-1365773705), this issue should be addressed in the plugin directly.  Relevant links:
[quartz github issue](https://github.com/quartz-scheduler/quartz/issues/467)
[maven central vulnerability](https://mvnrepository.com/artifact/org.grails.plugins/quartz/2.0.13)