### PR TITLE
chore(deps): Remove unused test deps

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,11 +34,8 @@ dependencies {
     compileOnly libs.groovy.core // CompileStatic and Slf4j
     compileOnly libs.javax.annotation.api // Provided
 
-    testImplementation libs.groovy.test
-    testImplementation libs.junit4
     testImplementation libs.spock.core
 
-    testRuntimeOnly libs.junit.vintage.engine // Needed for JUnit 4 tests to run
     testRuntimeOnly libs.slf4j.nop // Get rid of warning about missing slf4j implementation during test task
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,8 +2,6 @@
 grails = '6.1.2'
 groovy = '3.0.21'
 javax-annotation-api = '1.3.2'
-junit4 = '4.13'
-junit-jupiter = '5.10.2'
 quartz = '2.3.2'
 slf4j = '1.7.36'
 spring = '5.3.33'
@@ -16,10 +14,7 @@ grails-docs = { group = 'org.grails', name = 'grails-docs', version.ref = 'grail
 groovy-core = { group = 'org.codehaus.groovy', name = 'groovy', version.ref = 'groovy' }
 groovy-sql = { group = 'org.codehaus.groovy', name = 'groovy-sql', version.ref = 'groovy' }
 groovy-templates = { group = 'org.codehaus.groovy', name = 'groovy-templates', version.ref = 'groovy' }
-groovy-test = { group = 'org.codehaus.groovy', name = 'groovy-test', version.ref = 'groovy' }
 javax-annotation-api = { module = 'javax.annotation:javax.annotation-api', version.ref = 'javax-annotation-api' }
-junit4 = { group = 'junit', name = 'junit', version.ref = 'junit4' }
-junit-vintage-engine = { group = 'org.junit.vintage', name = 'junit-vintage-engine', version.ref = 'junit-jupiter' }
 quartz = { group = 'org.quartz-scheduler', name = 'quartz', version.ref = 'quartz' }
 slf4j-nop = { group = 'org.slf4j', name = 'slf4j-nop', version.ref = 'slf4j' }
 spring-beans = { group = 'org.springframework', name = 'spring-beans', version.ref = 'spring' }


### PR DESCRIPTION
The dependencies for old test frameworks are no longer required

Related: #126