### PR TITLE
Ensure purgeTablesBean uses the correct datasource during clean operation

### DIFF
--- a/src/main/groovy/quartz/QuartzGrailsPlugin.groovy
+++ b/src/main/groovy/quartz/QuartzGrailsPlugin.groovy
@@ -98,6 +98,7 @@ Adds Quartz job scheduling features
 
                 if (hasJdbcStore && hasHibernate && purgeTables) {
                     purgeTablesBean(JdbcCleanup) { bean ->
+                        dataSource = ref(properties['org.quartz.jdbcStoreDataSource'] ?: 'dataSource')
                         bean.autowire = 'byName'
                     }
                 }


### PR DESCRIPTION
Previously, when running the clean operation, the purgeTablesBean incorrectly targeted the main application dataSource instead of the jdbcStoreDataSource specified in the Quartz properties.

This PR updates the configuration of purgeTablesBean to dynamically resolve the dataSource based on the org.quartz.jdbcStoreDataSource property. If this property is not defined, it will fallback to the default dataSource.

- **Changes:**

Updated the purgeTablesBean to use properties['org.quartz.jdbcStoreDataSource'] ?: 'dataSource' for resolving the dataSource.
Ensures the clean operation now targets the correct database when jdbcStoreDataSource is provided.

- **Impact:**

This fix prevents unintended operations on the main application database when a custom jdbcStoreDataSource is configured.

- **Testing:**

Verified that clean operations now correctly use the jdbcStoreDataSource when specified.
Confirmed fallback to the main dataSource when org.quartz.jdbcStoreDataSource is not configured.