### PR TITLE
#139: loadQuartzProperties getProperty replaced with get

### DIFF
--- a/src/main/groovy/quartz/QuartzGrailsPlugin.groovy
+++ b/src/main/groovy/quartz/QuartzGrailsPlugin.groovy
@@ -155,10 +155,10 @@ Adds Quartz job scheduling features
      */
     def loadQuartzProperties() {
         Properties quartzProperties = new Properties()
-        if (config.getProperty('quartz')) {
+        if (config.get('quartz')) {
             // Convert to a properties file adding a prefix to each property
             ConfigObject configObject = new ConfigObject()
-            configObject.putAll(config.getProperty('quartz') ?: [:])
+            configObject.putAll(config.get('quartz') ?: [:])
             quartzProperties << configObject.toProperties('org.quartz')
         }
         quartzProperties


### PR DESCRIPTION
in loadQuartzProperties  getProperty won't retrieve the configuration properties. I replaced it with get