### PR TITLE
[skip ci] fix: add workaround in `verify.sh`

### DIFF
--- a/etc/bin/verify.sh
+++ b/etc/bin/verify.sh
@@ -71,7 +71,7 @@ else
     echo "ERROR: Neither gradlew nor gradle found on \$PATH." >&2
     exit 1
 fi
-${GRADLE_CMD}
+${GRADLE_CMD} --no-build-cache
 echo "✅ Gradle Bootstrapped"
 
 echo "Applying License Audit ..."


### PR DESCRIPTION
When running `verify.sh` in a container built from the Dockerfile, Gradle fails during the `gradle-bootstrap` step with the error:

    Build cache controller already set

Adding `--no-build-cache` flag works around this problem for now.