### PR TITLE
fix: `gradle-bootstrap` error

### DIFF
--- a/etc/bin/verify.sh
+++ b/etc/bin/verify.sh
@@ -71,7 +71,7 @@ else
     echo "ERROR: Neither gradlew nor gradle found on \$PATH." >&2
     exit 1
 fi
-${GRADLE_CMD} --no-build-cache
+${GRADLE_CMD}
 echo "✅ Gradle Bootstrapped"
 
 echo "Applying License Audit ..."

--- a/gradle-bootstrap/settings.gradle
+++ b/gradle-bootstrap/settings.gradle
@@ -1,0 +1,18 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */


### PR DESCRIPTION
`gradle-bootstrap` needs a `settings.gradle`
file (even empty) to not error with:

    Build cache controller already set

Related: gh-155