### PR TITLE
Change dependencies to compileOnly so they are not in POM or Gradle Module

### DIFF
--- a/.sdkmanrc
+++ b/.sdkmanrc
@@ -1,3 +1,3 @@
 # Enable auto-env through the sdkman_auto_env config - https://sdkman.io/usage#env
 java=17.0.15-librca
-gradle=8.14.2
+gradle=8.14.3

--- a/build.gradle
+++ b/build.gradle
@@ -57,9 +57,13 @@ repositories {
     }
 }
 
+grails {
+    springDependencyManagement = false
+}
+
 dependencies {
 
-    implementation platform("org.apache.grails:grails-bom:$grailsVersion")
+    compileOnly platform("org.apache.grails:grails-bom:$grailsVersion")
 
     api "org.quartz-scheduler:quartz:$quartzVersion", {
         // api: AdaptableJobFactory, InterruptableJob, JobExecutionContext, JobExecutionException,
@@ -67,22 +71,22 @@ dependencies {
         // runtime: @DisallowConcurrentExecution(runtime), @PersistJobDataAfterExecution(runtime)
     }
 
-    api 'org.springframework:spring-beans', {
+    compileOnly 'org.springframework:spring-beans', {
         // api: BeansException
         // impl: BeanUtils, BeanWrapper, FactoryBean, InitializingBean, PropertyAccessorFactory
     }
-    api 'org.springframework:spring-context', {
+    compileOnly 'org.springframework:spring-context', {
         // api: ApplicationContext
         // impl: ApplicationContextAware
     }
 
-    implementation 'org.apache.groovy:groovy-sql', {
+    compileOnly 'org.apache.groovy:groovy-sql', {
         // impl: Sql
     }
-    implementation 'org.springframework:spring-context-support', {
+    compileOnly 'org.springframework:spring-context-support', {
         // impl: AdaptableJobFactory
     }
-    implementation 'org.springframework:spring-core', {
+    compileOnly 'org.springframework:spring-core', {
         // impl: ReflectionUtils
     }
 
@@ -94,6 +98,8 @@ dependencies {
     compileOnly 'org.slf4j:slf4j-api', {
         // api: Logger, LoggerFactory
     }
+
+    testImplementation platform("org.apache.grails:grails-bom:$grailsVersion")
 
     testImplementation 'org.apache.grails:grails-core', {
         // impl: GrailsClass

--- a/build.gradle
+++ b/build.gradle
@@ -63,17 +63,15 @@ grails {
 
 dependencies {
 
-    api "org.quartz-scheduler:quartz:$quartzVersion", {
+    implementation platform("org.apache.grails:grails-bom:$grailsVersion")
+
+    api "org.quartz-scheduler:quartz", {
         // api: AdaptableJobFactory, InterruptableJob, JobExecutionContext, JobExecutionException,
         //      UnableToInterruptJobException, TriggerFiredBundle,
         // runtime: @DisallowConcurrentExecution(runtime), @PersistJobDataAfterExecution(runtime)
     }
 
-    compileOnly platform("org.apache.grails:grails-bom:$grailsVersion")
-
     compileOnly 'org.apache.grails:grails-dependencies-starter-web'
-
-    testImplementation platform("org.apache.grails:grails-bom:$grailsVersion")
 
     testImplementation 'org.apache.grails:grails-dependencies-test'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -63,48 +63,19 @@ grails {
 
 dependencies {
 
-    compileOnly platform("org.apache.grails:grails-bom:$grailsVersion")
-
     api "org.quartz-scheduler:quartz:$quartzVersion", {
         // api: AdaptableJobFactory, InterruptableJob, JobExecutionContext, JobExecutionException,
         //      UnableToInterruptJobException, TriggerFiredBundle,
         // runtime: @DisallowConcurrentExecution(runtime), @PersistJobDataAfterExecution(runtime)
     }
 
-    compileOnly 'org.springframework:spring-beans', {
-        // api: BeansException
-        // impl: BeanUtils, BeanWrapper, FactoryBean, InitializingBean, PropertyAccessorFactory
-    }
-    compileOnly 'org.springframework:spring-context', {
-        // api: ApplicationContext
-        // impl: ApplicationContextAware
-    }
+    compileOnly platform("org.apache.grails:grails-bom:$grailsVersion")
 
-    compileOnly 'org.apache.groovy:groovy-sql', {
-        // impl: Sql
-    }
-    compileOnly 'org.springframework:spring-context-support', {
-        // impl: AdaptableJobFactory
-    }
-    compileOnly 'org.springframework:spring-core', {
-        // impl: ReflectionUtils
-    }
-
-    compileOnly 'org.apache.grails:grails-core', { // Provided as this is a Grails Plugin
-        // api: PersistenceContextInterceptor
-        // impl: AbstractGrailsClass, GrailsClass, GrailsClassUtils
-    }
-    compileOnly 'org.apache.groovy:groovy' // Provided as this is a Grails Plugin
-    compileOnly 'org.slf4j:slf4j-api', {
-        // api: Logger, LoggerFactory
-    }
+    compileOnly 'org.apache.grails:grails-dependencies-starter-web'
 
     testImplementation platform("org.apache.grails:grails-bom:$grailsVersion")
 
-    testImplementation 'org.apache.grails:grails-core', {
-        // impl: GrailsClass
-    }
-    testImplementation 'org.spockframework:spock-core'
+    testImplementation 'org.apache.grails:grails-dependencies-test'
 }
 
 apply {

--- a/gradle.properties
+++ b/gradle.properties
@@ -22,7 +22,6 @@ javaVersion=17
 
 asciidoctorGradlePluginVersion=4.0.4
 gradleCryptoChecksumVersion=1.4.0
-quartzVersion=2.5.0
 ratVersion=0.8.1
 
 # This prevents the Grails Gradle Plugin from unnecessarily excluding slf4j-simple in the generated POMs

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
Switched several dependencies from implementation/api to compileOnly. Disabled Grails springDependencyManagement and added testImplementation for grails-bom.

Switched to `grails-dependencies-starter-web` and `grails-dependencies-test` dependencies to simplify

resolves:  https://github.com/apache/grails-quartz/issues/158