### PR TITLE
Pin GitHub Actions to Apache-approved commit hashes

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -38,7 +38,7 @@ jobs:
           java-version: 17
           distribution: liberica
       - name: "🐘 Setup Gradle"
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
         with:
           develocity-access-key: ${{ secrets.GRAILS_DEVELOCITY_ACCESS_KEY }}
       - name: "🏃‍♂️ Run Tests"
@@ -58,7 +58,7 @@ jobs:
           java-version: 17
           distribution: liberica
       - name: "🐘 Setup Gradle"
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
         with:
           develocity-access-key: ${{ secrets.GRAILS_DEVELOCITY_ACCESS_KEY }}
       - name: "📤 Publish Snapshot artifacts"

--- a/.github/workflows/rat.yml
+++ b/.github/workflows/rat.yml
@@ -40,9 +40,9 @@ jobs:
           distribution: liberica
           java-version: 17
       - name: "🐘 Setup Gradle"
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
         with:
-          develocity-access-key: ${{ secrets.GRAILS_DEVELOCITY_ACCESS_KEY  }}
+          develocity-access-key: ${{ secrets.GRAILS_DEVELOCITY_ACCESS_KEY }}
       - name: "🧐 Apache License - Release Audit Tool"
         run: ./gradlew rat
       - name: "📤 Upload RAT HTML report"

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -32,6 +32,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "📝 Update Release Draft"
-        uses: release-drafter/release-drafter@v6
+        uses: release-drafter/release-drafter@6a93d829887aa2e0748befe2e808c66c0ec6e4c7 # v6.4.0
         env:
           GITHUB_TOKEN: ${{ secrets.GRAILS_GH_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,7 +66,7 @@ jobs:
           distribution: ${{ env.JAVA_DISTRIBUTION }}
           java-version: ${{ env.JAVA_VERSION }}
       - name: "🐘 Setup Gradle"
-        uses: gradle/actions/setup-gradle@v5
+        uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
         with:
           develocity-access-key: ${{ secrets.GRAILS_DEVELOCITY_ACCESS_KEY }}
       - name: "⚙️ Run pre-release"
@@ -111,7 +111,7 @@ jobs:
       - name: "📅 Generate build date file"
         run: echo "$SOURCE_DATE_EPOCH" >> build/BUILD_DATE.txt
       - name: "📤 Upload build date, checksums and published artifacts files"
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2.6.1
         with:
           tag_name: ${{ env.TAG }}
           files: |
@@ -197,7 +197,7 @@ jobs:
           > "apache-${REPO_NAME}-${VERSION}-src.zip.sha512"
           cat "./apache-${REPO_NAME}-${VERSION}-src.zip.sha512"
       - name: "🚀 Upload ZIP and Signature to GitHub Release"
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2.6.1
         with:
           tag_name: ${{ env.TAG }}
           files: |
@@ -305,7 +305,7 @@ jobs:
           cd dev-repo
           svn info "$VERSION" > "DIST_SVN_REVISION.txt"
       - name: "📤 Upload the Distribution SVN revision file"
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2.6.1
         with:
           tag_name: ${{ env.TAG }}
           files: dev-repo/DIST_SVN_REVISION.txt
@@ -426,7 +426,7 @@ jobs:
           distribution: ${{ env.JAVA_DISTRIBUTION }}
           java-version: ${{ env.JAVA_VERSION }}
       - name: "🐘 Setup Gradle"
-        uses: gradle/actions/setup-gradle@v5
+        uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
         with:
           develocity-access-key: ${{ secrets.GRAILS_DEVELOCITY_ACCESS_KEY }}
       - name: "🔨 Build Documentation"
@@ -461,7 +461,7 @@ jobs:
           distribution: ${{ env.JAVA_DISTRIBUTION }}
           java-version: ${{ env.JAVA_VERSION }}
       - name: "🐘 Setup Gradle"
-        uses: gradle/actions/setup-gradle@v5
+        uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
         with:
           develocity-access-key: ${{ secrets.GRAILS_DEVELOCITY_ACCESS_KEY }}
       - name: "⚙️ Run post-release"


### PR DESCRIPTION
## Summary

- Pin third-party GitHub Actions to commit hashes from [apache/infrastructure-actions approved_patterns.yml](https://github.com/apache/infrastructure-actions/blob/main/approved_patterns.yml) for supply chain security compliance.

## Changes

| Workflow | Action | Before | After |
|---|---|---|---|
| `gradle.yml` (2x) | `gradle/actions/setup-gradle` | `@v4` | `@07231958...` (v5.0.2) |
| `rat.yml` | `gradle/actions/setup-gradle` | `@v4` | `@07231958...` (v5.0.2) |
| `release.yml` (3x) | `gradle/actions/setup-gradle` | `@v5` | `@07231958...` (v5.0.2) |
| `release-notes.yml` | `release-drafter/release-drafter` | `@v6` | `@6a93d829...` (v6.4.0) |
| `release.yml` (3x) | `softprops/action-gh-release` | `@v2` | `@153bb8e0...` (v2.6.1) |

All `gradle/actions/setup-gradle` references are standardized on v5.0.2. GitHub first-party actions (`actions/checkout`, `actions/setup-java`, `actions/upload-artifact`) and Apache's own actions (`apache/grails-github-actions/*`) remain on version/branch tags.